### PR TITLE
Grid example

### DIFF
--- a/apps/docs/components/Sidebar.tsx
+++ b/apps/docs/components/Sidebar.tsx
@@ -42,6 +42,7 @@ export const Sidebar = () => {
       <NavItem href="/examples/backgrounds">Backgrounds</NavItem>
       <NavItem href="/examples/space">Space</NavItem>
       <NavItem href="/examples/text-decoration">Text Decoration</NavItem>
+      <NavItem href="/examples/grid-layout">Grid Layout</NavItem>
       <NavSectionTitle>TODO</NavSectionTitle>
       <NavItem href="/unsupported">Unsupported Properties</NavItem>
       <NavItem href="https://github.com/components-ai/css.gui/issues">

--- a/apps/docs/components/Sidebar.tsx
+++ b/apps/docs/components/Sidebar.tsx
@@ -42,7 +42,6 @@ export const Sidebar = () => {
       <NavItem href="/examples/backgrounds">Backgrounds</NavItem>
       <NavItem href="/examples/space">Space</NavItem>
       <NavItem href="/examples/text-decoration">Text Decoration</NavItem>
-      <NavItem href="/examples/grid-layout">Grid Layout</NavItem>
       <NavSectionTitle>TODO</NavSectionTitle>
       <NavItem href="/unsupported">Unsupported Properties</NavItem>
       <NavItem href="https://github.com/components-ai/css.gui/issues">

--- a/apps/docs/pages/examples/grid-layout.tsx
+++ b/apps/docs/pages/examples/grid-layout.tsx
@@ -1,0 +1,76 @@
+import { Editor, styled } from '@compai/css-gui'
+import { useState } from 'react'
+
+const createElementStyles = () => ({
+  gridRowStart: Math.ceil(Math.random() * 6),
+  gridRowEnd: Math.ceil(Math.random() * 6),
+  gridColumnStart: Math.ceil(Math.random() * 6),
+  gridColumnEnd: Math.ceil(Math.random() * 6),
+  backgroundColor: 'red.' + Math.floor(Math.random() * 10),
+  offset: Math.random(),
+})
+
+export default function Shadows() {
+  const [elements, setElements] = useState([createElementStyles()])
+
+  const [perspective, setPerspective] = useState(256)
+  const [offset, setOffset] = useState(128)
+
+  return (
+    <div>
+      <button
+        onClick={(e) => setElements([...elements, createElementStyles()])}
+      >
+        +
+      </button>
+      <button onClick={(e) => setElements([...elements.slice(0, -1)])}>
+        -
+      </button>
+
+      <div>
+        <input
+          type="range"
+          value={perspective}
+          onChange={(e) => setPerspective(parseInt(e.target.value))}
+          min={0}
+          max={512}
+          step={1}
+        />
+        <br />
+        <input
+          type="range"
+          value={offset}
+          onChange={(e) => setOffset(parseInt(e.target.value))}
+          min={0}
+          max={512}
+          step={1}
+        />
+      </div>
+
+      <pre sx={{ width: 3 }}>
+        {elements.map((el) => JSON.stringify(el) + '\n')}
+      </pre>
+
+      <div
+        sx={{
+          m: 4,
+          display: 'grid',
+          justifyContent: 'center',
+          transformStyle: 'preserve-3d',
+          pointerEvents: 'none',
+          transform: `perspective(${perspective}px) rotateX(24deg) rotateY(36deg)`,
+        }}
+      >
+        {elements.map((el) => (
+          <div
+            sx={{
+              ...el,
+              p: 3,
+              transform: `translateZ(${offset * el.offset}px)`,
+            }}
+          ></div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/docs/pages/examples/grid-layout.tsx
+++ b/apps/docs/pages/examples/grid-layout.tsx
@@ -6,18 +6,28 @@ const createElementStyles = () => ({
   gridRowEnd: Math.ceil(Math.random() * 6),
   gridColumnStart: Math.ceil(Math.random() * 6),
   gridColumnEnd: Math.ceil(Math.random() * 6),
-  backgroundColor: 'red.' + Math.floor(Math.random() * 10),
   offset: Math.random(),
 })
 
-export default function Shadows() {
-  const [elements, setElements] = useState([createElementStyles()])
+const initialStyles = {
+  transform: [
+    { type: 'perspective', amount: { value: 512, unit: 'px' } },
+    { type: 'rotateX', amount: { value: 15, unit: 'deg' } },
+    { type: 'rotateY', amount: { value: 15, unit: 'deg' } },
+  ],
+}
 
-  const [perspective, setPerspective] = useState(256)
+export default function Shadows() {
+  const [styles, setStyles] = useState<any>(initialStyles)
+
+  const [elements, setElements] = useState([createElementStyles()])
   const [offset, setOffset] = useState(128)
+  const [string, setString] = useState('components.ai')
 
   return (
     <div>
+      <Editor styles={styles} onChange={setStyles} />
+
       <button
         onClick={(e) => setElements([...elements, createElementStyles()])}
       >
@@ -29,12 +39,9 @@ export default function Shadows() {
 
       <div>
         <input
-          type="range"
-          value={perspective}
-          onChange={(e) => setPerspective(parseInt(e.target.value))}
-          min={0}
-          max={512}
-          step={1}
+          type="text"
+          value={string}
+          onChange={(e) => setString(e.target.value)}
         />
         <br />
         <input
@@ -47,30 +54,43 @@ export default function Shadows() {
         />
       </div>
 
-      <pre sx={{ width: 3 }}>
+      <pre sx={{ position: 'absolute' }}>
         {elements.map((el) => JSON.stringify(el) + '\n')}
       </pre>
 
-      <div
-        sx={{
+      <styled.div
+        styles={{
           m: 4,
           display: 'grid',
           justifyContent: 'center',
           transformStyle: 'preserve-3d',
           pointerEvents: 'none',
-          transform: `perspective(${perspective}px) rotateX(24deg) rotateY(36deg)`,
+          ...styles,
         }}
       >
-        {elements.map((el) => (
-          <div
-            sx={{
-              ...el,
-              p: 3,
-              transform: `translateZ(${offset * el.offset}px)`,
-            }}
-          ></div>
-        ))}
-      </div>
+        {elements.map((el, i) => {
+          const deltaY = Math.abs(el.gridRowStart - el.gridRowEnd)
+          const deltaX = Math.abs(el.gridColumnStart - el.gridColumnEnd)
+
+          const area = (deltaX * deltaY) / 12
+
+          return (
+            <div
+              sx={{
+                ...el,
+                p: 3,
+                fontWeight: 900,
+                fontSize: Math.ceil((deltaX + 1) * 18) + 'px',
+                transform: `translateZ(${offset * (el.offset - 0.5)}px)`,
+                border: '1px solid',
+                borderColor: 'red.7',
+              }}
+            >
+              {string[i]}
+            </div>
+          )
+        })}
+      </styled.div>
     </div>
   )
 }


### PR DESCRIPTION
this is more of an art piece than a component right now, but using this space to develop some patterns for working with `<grid-line>` and `grid` layout concepts out in the open (#67). right now it only generates nonsense `int`-only `<grid-line>` values and projects them into 3D space.

<img width="941" alt="" src="https://user-images.githubusercontent.com/65447/166603352-750d7d1d-1a83-45df-a7d0-e75fc84bf46c.png">

due to the high-dimensionality of the Grid Layout Module, it'd probably make sense to land a subset of inside-out (grid-content controls) and outside-in (grid-container controls) properties and then expand to all the `<custom-ident>` and `minmax` layout stuff at a later date.