### PR TITLE
Allow user to enter numbers outside of limit

### DIFF
--- a/.changeset/curly-cobras-report.md
+++ b/.changeset/curly-cobras-report.md
@@ -1,0 +1,5 @@
+---
+'@compai/css-gui': patch
+---
+
+Allow user to type values out of bounds of limit range

--- a/packages/gui/src/components/primitives/Number/Input.tsx
+++ b/packages/gui/src/components/primitives/Number/Input.tsx
@@ -22,19 +22,19 @@ export const DraggableInput = ({
   const initialValue = React.useRef<number>(value)
 
   const bind = useDrag(
-    ({ dragging, first, tap, movement: [dx] }) => {
+    ({ dragging, first, last, tap, movement: [dx] }) => {
       setDragging(dragging)
       const parsedValue = typeof value === 'string' ? parseFloat(value) : value
 
-      if (tap) return
+      if (tap || last) return
       if (first) {
         initialValue.current = parsedValue
       }
 
       const deltaValue = dx * step
       let newValue = roundToStep(initialValue.current + deltaValue, step)
-      if (min || min === 0) newValue = Math.max(newValue, min)
-      if (max) newValue = Math.min(newValue, max)
+      if (dragging && (min || min === 0)) newValue = Math.max(newValue, min)
+      if (dragging && max) newValue = Math.min(newValue, max)
 
       onUpdate(newValue)
     },
@@ -47,8 +47,8 @@ export const DraggableInput = ({
       value={value}
       onChange={({ currentTarget: { value: inputValue } }) => {
         let newValue = parseFloat(inputValue)
-        if (min || min === 0) newValue = Math.max(newValue, min)
-        if (max) newValue = Math.min(newValue, max)
+        if (dragging && (min || min === 0)) newValue = Math.max(newValue, min)
+        if (dragging && max) newValue = Math.min(newValue, max)
 
         onUpdate(newValue)
       }}


### PR DESCRIPTION
number limits will only be applied if the user is dragging, otherwise the user may enter any value outside of specified range. 

Relevant bug for negative numbers #152

### Demo

https://user-images.githubusercontent.com/4340994/166963269-456cc98a-bf79-477f-8f67-188d95d22ae7.mov


