### PR TITLE
Pseudo element fixes

### DIFF
--- a/.changeset/large-lions-cheat.md
+++ b/.changeset/large-lions-cheat.md
@@ -1,0 +1,5 @@
+---
+'@compai/css-gui': patch
+---
+
+allows optional pseudo syntax for initial styles. Change default color to inherit

--- a/apps/docs/components/examples/Fieldset.tsx
+++ b/apps/docs/components/examples/Fieldset.tsx
@@ -8,8 +8,13 @@ import {
 } from '@compai/css-gui'
 
 export const Fieldset = () => {
-  const [styles, setStyles] = useState({})
-
+  const [styles, setStyles] = useState<any>({ 
+    '::first-letter': {
+      fontSize: { unit: 'px', value: 32 }
+    }, 
+    fontSize: { unit: 'px', value: 16 },
+  })
+  
   return (
     <>
       <Editor styles={styles} onChange={setStyles}>

--- a/apps/docs/pages/components/fieldset.mdx
+++ b/apps/docs/pages/components/fieldset.mdx
@@ -23,7 +23,12 @@ import { useState } from 'react'
 import { Editor, Fieldset, Inputs, styled } from '@compai/css-gui'
 
 const MyEditor = () => {
-  const [styles, setStyles] = useState({})
+  const [styles, setStyles] = useState({ 
+    '::first-letter': {
+      fontSize: { unit: 'px', value: 32 }
+    }, 
+    fontSize: { unit: 'px', value: 16 },
+  }))
 
   return (
     <>

--- a/packages/gui/src/components/Editor/Controls.tsx
+++ b/packages/gui/src/components/Editor/Controls.tsx
@@ -30,7 +30,7 @@ import { DimensionInput } from '../inputs/Dimension'
 import { SelectInput } from '../inputs/SelectInput'
 import { GLOBAL_KEYWORDS } from '../../data/global-keywords'
 import { Label } from '../primitives'
-import { camelCase, kebabCase } from 'lodash-es'
+import { camelCase, kebabCase, uniq } from 'lodash-es'
 import { useThemeProperty } from '../providers/ThemeContext'
 import { PositionInput } from '../inputs/PositionInput'
 import { TimeInput } from '../inputs/TimeInput'
@@ -42,6 +42,7 @@ import { DEFAULT_LENGTH } from '../../lib/constants'
 import { getDefaultValue } from '../../lib/defaults'
 import { MultidimensionInput } from '../inputs/Multidimension'
 import { Responsive } from '../Responsive/Input'
+import { addPseudoSyntax } from '../../lib/pseudos'
 
 interface ControlProps extends InputProps {
   field: KeyArg
@@ -63,7 +64,11 @@ const Control = ({ field, ...props }: ControlProps) => {
     return null
   }
 
-  const fullField = fieldset ? joinPath(fieldset.name, field) : field
+  const fieldsetName = fieldset && getField(fieldset.name)
+    ? fieldset.name
+    : addPseudoSyntax(fieldset?.name as string)
+
+  const fullField = fieldsetName ? joinPath(fieldsetName, field) : field
   const componentProps = {
     label: sentenceCase(property),
     themeValues: themeValues,
@@ -140,7 +145,7 @@ export const Editor = ({
   children,
   hideResponsiveControls,
 }: ControlsProps) => {
-  const properties = Object.keys(styles)
+  const properties = uniq(Object.keys(styles).map(p => p.replace(/^:+/, '')))
 
   const handleStylesChange = (recipe: Recipe<EditorData<any>>) => {
     const newData = produce(styles, (draft: any) => {
@@ -153,6 +158,7 @@ export const Editor = ({
       draft = valueData as any
     })
 
+    console.log(newData, "newData")
     onChange(newData)
   }
 
@@ -395,8 +401,8 @@ function getDefaultsFromChildren(children: ReactNode): Record<string, any> {
       typeof element.type === 'function' &&
       (element.type as any).displayName
     ) {
-      // console.log('ran into a field')
       const property = camelCase((element.type as any).displayName)
+      // console.log(property, 'ran into a field')
       defaults = {
         ...defaults,
         [property]: getDefaultValue(property),

--- a/packages/gui/src/components/Editor/Controls.tsx
+++ b/packages/gui/src/components/Editor/Controls.tsx
@@ -158,7 +158,6 @@ export const Editor = ({
       draft = valueData as any
     })
 
-    console.log(newData, "newData")
     onChange(newData)
   }
 
@@ -402,15 +401,12 @@ function getDefaultsFromChildren(children: ReactNode): Record<string, any> {
       (element.type as any).displayName
     ) {
       const property = camelCase((element.type as any).displayName)
-      // console.log(property, 'ran into a field')
       defaults = {
         ...defaults,
         [property]: getDefaultValue(property),
       }
     }
     if (element.props.children) {
-      // console.log('ran into element with children')
-      // console.log(element.props.children)
       defaults = {
         ...defaults,
         ...getDefaultsFromChildren(element.props.children),

--- a/packages/gui/src/components/Editor/Fieldset.tsx
+++ b/packages/gui/src/components/Editor/Fieldset.tsx
@@ -27,7 +27,6 @@ export const Fieldset = ({ type, name, children }: FieldsetProps) => {
   const fullName = outerNames.length
     ? [...outerNames, name]
     : (name as FieldsetNames)
-    console.log(fullName, "fullName")
   return (
     // @ts-ignore
     <FieldsetContext.Provider value={{ type, name: fullName }}>

--- a/packages/gui/src/components/Editor/Fieldset.tsx
+++ b/packages/gui/src/components/Editor/Fieldset.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { elements } from '../../data/elements'
 import { pseudoClasses } from '../../data/pseudo-classes'
 import { pseudoElements } from '../../data/pseudo-elements'
+import { addPseudoSyntax } from '../../lib/pseudos'
 
 type PseudoElementTypes = typeof pseudoElements[number]
 type PseudoClassTypes = typeof pseudoClasses[number]
@@ -26,6 +27,7 @@ export const Fieldset = ({ type, name, children }: FieldsetProps) => {
   const fullName = outerNames.length
     ? [...outerNames, name]
     : (name as FieldsetNames)
+    console.log(fullName, "fullName")
   return (
     // @ts-ignore
     <FieldsetContext.Provider value={{ type, name: fullName }}>

--- a/packages/gui/src/lib/codegen/to-css-object.ts
+++ b/packages/gui/src/lib/codegen/to-css-object.ts
@@ -33,7 +33,7 @@ export const toCSSObject = (styles: Styles): any => {
   // @ts-ignore
   return Object.entries(styles).reduce((acc: Styles, curr: StyleEntry) => {
     const [property, value] = curr
-    if (isNestedSelector(property)) {
+    if (isNestedSelector(property.replace(/^:+/, ''))) {
       return {
         ...acc,
         [stringifySelector(property)]: toCSSObject(value as Styles),

--- a/packages/gui/src/lib/defaults.ts
+++ b/packages/gui/src/lib/defaults.ts
@@ -6,6 +6,7 @@ export function getDefaultValue(property: string) {
   if (propertyDefinition.defaultValue) {
     return propertyDefinition.defaultValue
   }
+  
   switch (propertyDefinition.type) {
     case 'keyword':
       return { value: propertyDefinition.keywords![0], unit: 'keyword' }
@@ -21,7 +22,7 @@ export function getDefaultValue(property: string) {
     case 'string':
       return { value: '', unit: 'string' }
     case 'color':
-      return 'transparent'
+      return 'inherit'
     case 'position':
       return {
         x: { value: 0, unit: '%' },

--- a/packages/gui/src/lib/defaults.ts
+++ b/packages/gui/src/lib/defaults.ts
@@ -6,7 +6,6 @@ export function getDefaultValue(property: string) {
   if (propertyDefinition.defaultValue) {
     return propertyDefinition.defaultValue
   }
-  
   switch (propertyDefinition.type) {
     case 'keyword':
       return { value: propertyDefinition.keywords![0], unit: 'keyword' }

--- a/packages/gui/src/lib/pseudos.ts
+++ b/packages/gui/src/lib/pseudos.ts
@@ -15,6 +15,6 @@ export const addPseudoSyntax = (str: string): string => {
   } else if (isPseudoElement(str)) {
     return '::' + str
   }
-
+  // console.log(str, 'returning')
   return str
 }

--- a/packages/gui/src/lib/pseudos.ts
+++ b/packages/gui/src/lib/pseudos.ts
@@ -15,6 +15,6 @@ export const addPseudoSyntax = (str: string): string => {
   } else if (isPseudoElement(str)) {
     return '::' + str
   }
-  // console.log(str, 'returning')
+
   return str
 }


### PR DESCRIPTION
* Fixes initialisation of pseudo elements by allowing use of pseudo styles (though, still optional)
* In some additional default properties are added into the styles object. Still unsure why this only happens sometimes but for now set default color to `inherit` so not to create a potentially confusing output.