### PR TITLE
Hide none schema type

### DIFF
--- a/.changeset/long-beds-visit.md
+++ b/.changeset/long-beds-visit.md
@@ -1,0 +1,5 @@
+---
+'@compai/css-gui': patch
+---
+
+Properly hide none schema type, tie in variable fonts

--- a/packages/gui/src/components/Editor/Controls.tsx
+++ b/packages/gui/src/components/Editor/Controls.tsx
@@ -84,6 +84,10 @@ const Control = ({ field, showRemove = false, ...props }: ControlProps) => {
 
   const schema = properties[property]
 
+  if (schema.type === 'none') {
+    return null
+  }
+
   return (
     <SchemaInput
       label={sentenceCase(property)}

--- a/packages/gui/src/components/schemas/topLevel.ts
+++ b/packages/gui/src/components/schemas/topLevel.ts
@@ -4,8 +4,10 @@ import { keyword } from './primitives'
 import { responsive } from './responsive'
 import { DataTypeSchema } from './types'
 
+const NO_GLOBAL_SCHEMA_PROPERTIES = ['fontFamily', 'fontVariationSettings']
+
 export function topLevel<T>(schema: DataTypeSchema<T>, property: string) {
-  if (property === 'fontFamily') {
+  if (NO_GLOBAL_SCHEMA_PROPERTIES.includes(property)) {
     return schema
   }
   const withGlobal = joinSchemas([schema, global])

--- a/packages/gui/src/data/properties.ts
+++ b/packages/gui/src/data/properties.ts
@@ -100,6 +100,13 @@ function normalizeSchema(propertyData: PropertyData): DataTypeSchema<any> {
     if (input === 'keyword') {
       // const { keywords = [], ...rest } = propertyData
       return keyword(keywords!, propertyData)
+    } else if (input === 'none') {
+      return {
+        type: 'none',
+        defaultValue: null,
+        validate: (() => true) as any,
+        stringify: (value) => String(value),
+      }
     } else {
       let schema = primitiveMap[input](propertyData) as any
       return joinSchemas(


### PR DESCRIPTION
None schema types, like fontVariationSettings, are skipped in rendering
and don't bother with stringifying. This can be used for properties that
are dependent on others (like variable fonts).

In the future we can likely make this fontVariationSettings specific
since this is currently the only place this behavior is implemented.
But this works for now.