### PR TITLE
Extract canvas prop instantiation to its own hook

### DIFF
--- a/.changeset/shy-adults-turn.md
+++ b/.changeset/shy-adults-turn.md
@@ -1,0 +1,5 @@
+---
+'@compai/css-gui': patch
+---
+
+Internal refactor for canvas prop instantiation

--- a/packages/gui/src/components/html/CanvasProvider.tsx
+++ b/packages/gui/src/components/html/CanvasProvider.tsx
@@ -1,0 +1,81 @@
+import { createContext, ReactNode, useContext } from 'react'
+import { toCSSObject } from '../../lib/codegen/to-css-object'
+import { toReactProps } from '../../lib/codegen/to-react-props'
+import { useTheme } from '../providers/ThemeContext'
+import { useHtmlEditor } from './Provider'
+import { ElementPath, HtmlNode } from './types'
+import { cleanAttributesForCanvas, isSamePath } from './util'
+
+const DEFAULT_CANVAS_VALUE = {}
+const DEFAULT_ELEMENT_STYLES_IN_CANVAS = {
+  cursor: 'default',
+}
+
+type CanvasProviderType = {
+  canvas?: boolean
+}
+
+export function useCanvas() {
+  const context = useContext(CanvasContext)
+  return context
+}
+
+type UseCanvasPropsArguments = {
+  path: ElementPath
+  value: HtmlNode
+}
+
+export function useCanvasProps({ path, value }: UseCanvasPropsArguments) {
+  const { canvas } = useContext(CanvasContext)
+  const { selected, setSelected } = useHtmlEditor()
+  const theme = useTheme()
+
+  const { attributes = {}, style = {} } = value
+
+  const sx = toCSSObject(
+    {
+      ...(canvas ? DEFAULT_ELEMENT_STYLES_IN_CANVAS : {}),
+      ...style,
+    },
+    theme
+  )
+
+  if (isSamePath(path, selected) && canvas) {
+    sx.outlineWidth = 'thin'
+    sx.outlineStyle = 'solid'
+    sx.outlineColor = 'primary'
+    sx.outlineOffset = '4px'
+    sx.userSelect = 'none'
+  }
+
+  const handleSelect = (e: MouseEvent) => {
+    if (!canvas) {
+      return
+    }
+
+    e.stopPropagation()
+    setSelected(path)
+  }
+
+  const props = toReactProps({
+    ...(canvas ? cleanAttributesForCanvas(attributes) : attributes),
+    sx,
+    onClick: handleSelect,
+  })
+
+  return props
+}
+
+const CanvasContext = createContext<CanvasProviderType>(DEFAULT_CANVAS_VALUE)
+
+type CanvasProviderProps = CanvasProviderType & {
+  children: ReactNode
+}
+
+export function CanvasProvider({ children, canvas }: CanvasProviderProps) {
+  return (
+    <CanvasContext.Provider value={{ canvas }}>
+      {children}
+    </CanvasContext.Provider>
+  )
+}

--- a/packages/gui/src/components/html/util.ts
+++ b/packages/gui/src/components/html/util.ts
@@ -12,6 +12,18 @@ export const isSamePath = (
   return path1.join('-') === path2.join('-')
 }
 
+export const cleanAttributesForCanvas = (
+  attributes: Record<string, string>
+) => {
+  const newAttributes = { ...attributes }
+
+  if (newAttributes.href) {
+    newAttributes.href = '#!'
+  }
+
+  return newAttributes
+}
+
 export function getChildAtPath(element: HtmlNode, path: ElementPath): HtmlNode {
   if (path.length === 0) {
     return element


### PR DESCRIPTION
Now that we have components and slots, there's a bit more complexity
to how we handle things like canvas selection and rendering. So, this
breaks this logic out into a standalone hook to make things more clear
around what's happening.

Refactor to prep for #487
Related to #467