### PR TITLE
Improve visual clutter of "add child" button

### DIFF
--- a/packages/gui/src/components/html/Provider.tsx
+++ b/packages/gui/src/components/html/Provider.tsx
@@ -15,6 +15,8 @@ const DEFAULT_HTML_EDITOR_VALUE = {
       <a href="https://components.ai">I'm a link!</a>
     </div>
   `),
+  isEditing: false,
+  setEditing: () => {},
   hasComponents: false,
 }
 
@@ -23,6 +25,8 @@ export type HtmlEditor = {
   theme?: any
   selected: ElementPath | null
   setSelected: (newSelection: ElementPath | null) => void
+  isEditing: boolean
+  setEditing(value: boolean): void
   components?: ComponentData[]
   hasComponents: boolean
 }
@@ -86,6 +90,7 @@ export function HtmlEditorProvider({
   components = [],
 }: HtmlEditorProviderProps) {
   const [selected, setSelected] = useState<ElementPath | null>([])
+  const [isEditing, setEditing] = useState(false)
   const transformedValue = transformValueToSchema(value)
 
   const fullContext = {
@@ -94,6 +99,8 @@ export function HtmlEditorProvider({
     setSelected: (newSelection: ElementPath | null) =>
       setSelected(newSelection),
     components,
+    isEditing,
+    setEditing: (newValue: any) => setEditing(newValue),
     hasComponents: !!components.length,
   }
 

--- a/packages/gui/src/components/html/TreeNode.tsx
+++ b/packages/gui/src/components/html/TreeNode.tsx
@@ -8,6 +8,8 @@ import { hasChildrenSlot } from '../../lib/codegen/util'
 import { Combobox } from '../primitives'
 import { HTML_TAGS } from './data'
 import { DEFAULT_ATTRIBUTES, DEFAULT_STYLES } from './default-styles'
+import { Icon } from '@radix-ui/react-select'
+import { Plus } from 'react-feather'
 
 interface EditorProps {
   value: HtmlNode
@@ -204,50 +206,41 @@ export function TreeNode({ value, path, onSelect, onChange }: TreeNodeProps) {
       <span sx={{ lineHeight: 1, fontFamily: 'monospace' }}>{tagButton}</span>
       <Collapsible.Content>
         <div sx={{ ml: 4 }}>
-          {value.children?.length ? (
-            value.children?.map((child, i) => {
-              return (
-                <Fragment key={i}>
-                  <AddChildButton
-                    onClick={() => {
-                      onChange(addChildAtPath(value, [i], DEFAULT_CHILD_NODE))
-                      onSelect([...path, i])
-                    }}
-                  />
-                  <TreeNode
-                    value={child}
-                    onSelect={onSelect}
-                    path={[...path, i]}
-                    onChange={(newChild) => {
-                      onChange({
-                        ...value,
-                        children: replaceAt(value.children ?? [], i, newChild),
-                      })
-                    }}
-                  />
-                  <AddChildButton
-                    onClick={() => {
-                      onChange(
-                        addChildAtPath(
-                          value,
-                          [value.children?.length ?? 0],
-                          DEFAULT_CHILD_NODE
-                        )
-                      )
-                      onSelect(null)
-                    }}
-                  />
-                </Fragment>
+          {value.children?.map((child, i) => {
+            return (
+              <Fragment key={i}>
+                <AddChildButton
+                  onClick={() => {
+                    onChange(addChildAtPath(value, [i], DEFAULT_CHILD_NODE))
+                    onSelect([...path, i])
+                  }}
+                />
+                <TreeNode
+                  value={child}
+                  onSelect={onSelect}
+                  path={[...path, i]}
+                  onChange={(newChild) => {
+                    onChange({
+                      ...value,
+                      children: replaceAt(value.children ?? [], i, newChild),
+                    })
+                  }}
+                />
+              </Fragment>
+            )
+          })}
+          <AddChildButton
+            onClick={() => {
+              onChange(
+                addChildAtPath(
+                  value,
+                  [value.children?.length ?? 0],
+                  DEFAULT_CHILD_NODE
+                )
               )
-            })
-          ) : (
-            <AddChildButton
-              onClick={() => {
-                onChange(addChildAtPath(value, [0], DEFAULT_CHILD_NODE))
-                onSelect([0])
-              }}
-            />
-          )}
+              onSelect(null)
+            }}
+          />
         </div>
         <div sx={{ display: 'flex', alignItems: 'center' }}>
           <div
@@ -311,27 +304,39 @@ const DEFAULT_CHILD_NODE: HtmlNode = {
 }
 
 function AddChildButton({ onClick }: { onClick(): void }) {
+  const [hovered, setHovered] = useState(false)
   return (
-    <button
-      onClick={onClick}
-      sx={{
-        cursor: 'pointer',
-        display: 'block',
-        background: 'none',
-        border: 'none',
-        textAlign: 'left',
-        fontSize: 0,
-        pt: 2,
-        whiteSpace: 'nowrap',
-        color: 'muted',
-        zIndex: '99',
-        transition: 'color .2s ease-in-out',
-        ':hover': {
-          color: 'text',
-        },
-      }}
-    >
-      + Add child
-    </button>
+    <div sx={{ position: 'relative' }}>
+      <button
+        sx={{
+          '--height': '1rem',
+          display: 'flex',
+          alignItems: 'center',
+          position: 'absolute',
+          height: 'var(--height)',
+          top: 'calc(var(--height) / -2 )',
+          width: '100%',
+          cursor: 'pointer',
+          ':hover': {
+            color: 'muted',
+          },
+
+          background: 'transparent',
+          border: 'none',
+
+          '::before': {
+            content: '""',
+            backgroundColor: hovered ? 'muted' : 'transparent',
+            display: 'block',
+            height: '2px',
+            width: '100%',
+          },
+        }}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+      >
+        <Plus size={16} />
+      </button>
+    </div>
   )
 }

--- a/packages/gui/src/components/html/TreeNode.tsx
+++ b/packages/gui/src/components/html/TreeNode.tsx
@@ -1,6 +1,6 @@
 import { HtmlNode, ElementPath } from './types'
 import * as Collapsible from '@radix-ui/react-collapsible'
-import { Fragment, useState } from 'react'
+import { useState } from 'react'
 import { useHtmlEditor } from './Provider'
 import { isVoidElement } from '../../lib/elements'
 import { addChildAtPath, isSamePath, replaceAt } from './util'
@@ -311,7 +311,7 @@ function AddChildButton({ onClick }: { onClick(type: string): void }) {
       <DropdownMenu.Root open={open} onOpenChange={setOpen}>
         <DropdownMenu.Trigger
           sx={{
-            '--height': '1rem',
+            '--height': '0.5rem',
             display: 'flex',
             alignItems: 'center',
             position: 'absolute',

--- a/packages/gui/src/components/html/TreeNode.tsx
+++ b/packages/gui/src/components/html/TreeNode.tsx
@@ -210,28 +210,30 @@ export function TreeNode({ value, path, onSelect, onChange }: TreeNodeProps) {
       />
       <span sx={{ lineHeight: 1, fontFamily: 'monospace' }}>{tagButton}</span>
       <Collapsible.Content>
-        <div sx={{ ml: 4 }}>
+        <div sx={{ ml: 4, py: '0.0625rem' }}>
           {value.children?.map((child, i) => {
             return (
-              <Fragment key={i}>
+              <div key={i}>
                 <AddChildButton
                   onClick={(childType) => {
                     handleAddChild(i, childType)
                     onSelect([...path, i])
                   }}
                 />
-                <TreeNode
-                  value={child}
-                  onSelect={onSelect}
-                  path={[...path, i]}
-                  onChange={(newChild) => {
-                    onChange({
-                      ...value,
-                      children: replaceAt(value.children ?? [], i, newChild),
-                    })
-                  }}
-                />
-              </Fragment>
+                <div sx={{ py: '0.0625rem' }}>
+                  <TreeNode
+                    value={child}
+                    onSelect={onSelect}
+                    path={[...path, i]}
+                    onChange={(newChild) => {
+                      onChange({
+                        ...value,
+                        children: replaceAt(value.children ?? [], i, newChild),
+                      })
+                    }}
+                  />
+                </div>
+              </div>
             )
           })}
           <AddChildButton
@@ -303,9 +305,10 @@ const DEFAULT_TEXT: HtmlNode = {
 
 function AddChildButton({ onClick }: { onClick(type: string): void }) {
   const [hovered, setHovered] = useState(false)
+  const [open, setOpen] = useState(false)
   return (
     <div sx={{ position: 'relative' }}>
-      <DropdownMenu.Root>
+      <DropdownMenu.Root open={open} onOpenChange={setOpen}>
         <DropdownMenu.Trigger
           sx={{
             '--height': '1rem',
@@ -325,7 +328,7 @@ function AddChildButton({ onClick }: { onClick(type: string): void }) {
 
             '::before': {
               content: '""',
-              backgroundColor: hovered ? 'muted' : 'transparent',
+              backgroundColor: hovered || open ? 'muted' : 'transparent',
               display: 'block',
               height: '2px',
               width: '100%',

--- a/packages/gui/src/components/html/TreeNode.tsx
+++ b/packages/gui/src/components/html/TreeNode.tsx
@@ -21,13 +21,17 @@ interface TreeNodeProps extends EditorProps {
 }
 
 export function TreeNode({ value, path, onSelect, onChange }: TreeNodeProps) {
-  const { selected } = useHtmlEditor()
+  const { selected, isEditing, setEditing } = useHtmlEditor()
   const [open, setOpen] = useState(true)
-  const [editing, setEditing] = useState(false)
   const isSelected = isSamePath(path, selected)
+  const isEditingNode = isSelected && isEditing
 
-  if (editing && !isSelected) {
-    setEditing(false)
+  function handleSelect() {
+    // If we are selecting a different node than the currently selected node, move out of editing mode
+    if (!isSelected) {
+      setEditing(false)
+    }
+    onSelect(path)
   }
 
   if (value.type === 'text') {
@@ -44,9 +48,11 @@ export function TreeNode({ value, path, onSelect, onChange }: TreeNodeProps) {
             fontSize: 0,
             width: '100%',
           }}
-          onClick={() => onSelect(path)}
+          onClick={() => {
+            handleSelect()
+          }}
         >
-          {editing ? (
+          {isEditingNode ? (
             <textarea
               sx={{
                 display: 'block',
@@ -99,7 +105,7 @@ export function TreeNode({ value, path, onSelect, onChange }: TreeNodeProps) {
             textAlign: 'start',
             fontSize: 0,
           }}
-          onClick={() => onSelect(path)}
+          onClick={() => handleSelect()}
         >
           {value.name}: "{value.value}"
         </button>
@@ -107,7 +113,7 @@ export function TreeNode({ value, path, onSelect, onChange }: TreeNodeProps) {
     )
   }
 
-  const tagEditor = editing ? (
+  const tagEditor = isEditingNode ? (
     <Combobox
       key={selected?.join('-')}
       onFilterItems={(filterValue) => {
@@ -168,7 +174,9 @@ export function TreeNode({ value, path, onSelect, onChange }: TreeNodeProps) {
         textAlign: 'start',
         display: 'inline-flex',
       }}
-      onClick={() => onSelect(path)}
+      onClick={() => {
+        handleSelect()
+      }}
     >
       &lt;{tagEditor}
       {!open || isSelfClosing(value) ? ' /' : null}&gt;

--- a/packages/gui/src/components/html/TreeNode.tsx
+++ b/packages/gui/src/components/html/TreeNode.tsx
@@ -226,6 +226,7 @@ export function TreeNode({ value, path, onSelect, onChange }: TreeNodeProps) {
                   onClick={(childType) => {
                     handleAddChild(i, childType)
                     onSelect([...path, i])
+                    setEditing(true)
                   }}
                 />
                 <div sx={{ py: '0.0625rem' }}>
@@ -246,8 +247,10 @@ export function TreeNode({ value, path, onSelect, onChange }: TreeNodeProps) {
           })}
           <AddChildButton
             onClick={(childType) => {
-              handleAddChild(value.children?.length ?? 0, childType)
-              onSelect(null)
+              const index = value.children?.length ?? 0
+              handleAddChild(index, childType)
+              onSelect([...path, index])
+              setEditing(true)
             }}
           />
         </div>

--- a/packages/gui/src/components/html/TreeNode.tsx
+++ b/packages/gui/src/components/html/TreeNode.tsx
@@ -8,8 +8,8 @@ import { hasChildrenSlot } from '../../lib/codegen/util'
 import { Combobox } from '../primitives'
 import { HTML_TAGS } from './data'
 import { DEFAULT_ATTRIBUTES, DEFAULT_STYLES } from './default-styles'
-import { Icon } from '@radix-ui/react-select'
 import { Plus } from 'react-feather'
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 
 interface EditorProps {
   value: HtmlNode
@@ -179,6 +179,11 @@ export function TreeNode({ value, path, onSelect, onChange }: TreeNodeProps) {
     return tagButton
   }
 
+  function handleAddChild(i: number, type: string) {
+    const child = type === 'tag' ? DEFAULT_TAG : DEFAULT_TEXT
+    onChange(addChildAtPath(value, [i], child))
+  }
+
   return (
     <Collapsible.Root open={open} onOpenChange={setOpen}>
       <Collapsible.Trigger
@@ -210,8 +215,8 @@ export function TreeNode({ value, path, onSelect, onChange }: TreeNodeProps) {
             return (
               <Fragment key={i}>
                 <AddChildButton
-                  onClick={() => {
-                    onChange(addChildAtPath(value, [i], DEFAULT_CHILD_NODE))
+                  onClick={(childType) => {
+                    handleAddChild(i, childType)
                     onSelect([...path, i])
                   }}
                 />
@@ -230,14 +235,8 @@ export function TreeNode({ value, path, onSelect, onChange }: TreeNodeProps) {
             )
           })}
           <AddChildButton
-            onClick={() => {
-              onChange(
-                addChildAtPath(
-                  value,
-                  [value.children?.length ?? 0],
-                  DEFAULT_CHILD_NODE
-                )
-              )
+            onClick={(childType) => {
+              handleAddChild(value.children?.length ?? 0, childType)
               onSelect(null)
             }}
           />
@@ -292,51 +291,82 @@ const isSelfClosing = (node: HtmlNode) => {
   return !hasChildrenSlot(node.value)
 }
 
-const DEFAULT_CHILD_NODE: HtmlNode = {
+const DEFAULT_TAG: HtmlNode = {
   type: 'element',
   tagName: 'div',
-  children: [
-    {
-      type: 'text',
-      value: '',
-    },
-  ],
 }
 
-function AddChildButton({ onClick }: { onClick(): void }) {
+const DEFAULT_TEXT: HtmlNode = {
+  type: 'text',
+  value: '',
+}
+
+function AddChildButton({ onClick }: { onClick(type: string): void }) {
   const [hovered, setHovered] = useState(false)
   return (
     <div sx={{ position: 'relative' }}>
-      <button
-        sx={{
-          '--height': '1rem',
-          display: 'flex',
-          alignItems: 'center',
-          position: 'absolute',
-          height: 'var(--height)',
-          top: 'calc(var(--height) / -2 )',
-          width: '100%',
-          cursor: 'pointer',
-          ':hover': {
-            color: 'muted',
-          },
-
-          background: 'transparent',
-          border: 'none',
-
-          '::before': {
-            content: '""',
-            backgroundColor: hovered ? 'muted' : 'transparent',
-            display: 'block',
-            height: '2px',
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger
+          sx={{
+            '--height': '1rem',
+            display: 'flex',
+            alignItems: 'center',
+            position: 'absolute',
+            height: 'var(--height)',
+            top: 'calc(var(--height) / -2 )',
             width: '100%',
-          },
-        }}
-        onMouseEnter={() => setHovered(true)}
-        onMouseLeave={() => setHovered(false)}
-      >
-        <Plus size={16} />
-      </button>
+            cursor: 'pointer',
+            ':hover': {
+              color: 'muted',
+            },
+
+            background: 'transparent',
+            border: 'none',
+
+            '::before': {
+              content: '""',
+              backgroundColor: hovered ? 'muted' : 'transparent',
+              display: 'block',
+              height: '2px',
+              width: '100%',
+            },
+          }}
+          onMouseEnter={() => setHovered(true)}
+          onMouseLeave={() => setHovered(false)}
+        >
+          <Plus size={16} />
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content
+          sx={{
+            minWidth: '12rem',
+            border: '1px solid',
+            borderColor: 'border',
+            borderRadius: '0.25rem',
+            backgroundColor: 'background',
+            py: 2,
+          }}
+        >
+          {['tag', 'text'].map((childType) => {
+            return (
+              <DropdownMenu.Item
+                key={childType}
+                onClick={() => {
+                  onClick(childType)
+                }}
+                sx={{
+                  cursor: 'pointer',
+                  px: 3,
+                  ':hover': {
+                    backgroundColor: 'backgroundOffset',
+                  },
+                }}
+              >
+                Add {childType}
+              </DropdownMenu.Item>
+            )
+          })}
+        </DropdownMenu.Content>
+      </DropdownMenu.Root>
     </div>
   )
 }


### PR DESCRIPTION
Reduce visual clutter by having a dropdown menu and being able to select tags or child (or components in the future)

https://user-images.githubusercontent.com/1278991/179896112-8fcb772b-2bb5-4f4f-a992-b4b308ad31cb.mov

