### PR TITLE
Inline text editing

### DIFF
--- a/.changeset/great-planes-worry.md
+++ b/.changeset/great-planes-worry.md
@@ -1,0 +1,5 @@
+---
+'@compai/css-gui': patch
+---
+
+Implement inline text editing

--- a/apps/docs/pages/dev.tsx
+++ b/apps/docs/pages/dev.tsx
@@ -133,6 +133,7 @@ export default function HtmlEditorExample() {
   return (
     <HtmlEditorProvider
       value={html}
+      onChange={setHtml}
       components={initialComponents}
       theme={defaultTheme}
     >
@@ -152,7 +153,7 @@ export default function HtmlEditorExample() {
             height: '100%',
           }}
         >
-          <HtmlEditor onChange={setHtml} />
+          <HtmlEditor />
         </div>
         <div
           sx={{

--- a/apps/docs/pages/html-editor.tsx
+++ b/apps/docs/pages/html-editor.tsx
@@ -7,7 +7,7 @@ export default function HtmlEditorExample() {
   const [html, setHtml] = useState(initialValue)
 
   return (
-    <HtmlEditorProvider value={html} theme={defaultTheme}>
+    <HtmlEditorProvider value={html} onChange={setHtml} theme={defaultTheme}>
       <div
         sx={{
           display: 'grid',
@@ -24,7 +24,7 @@ export default function HtmlEditorExample() {
             height: '100%',
           }}
         >
-          <HtmlEditor onChange={setHtml} />
+          <HtmlEditor />
         </div>
         <div
           sx={{

--- a/packages/gui/src/components/html/Component/Provider.tsx
+++ b/packages/gui/src/components/html/Component/Provider.tsx
@@ -1,6 +1,6 @@
 import { createContext, ReactNode, useContext } from 'react'
 import { useHtmlEditor } from '../Provider'
-import { ComponentData, ElementPath } from '../types'
+import { ComponentData, ElementPath, HtmlNode } from '../types'
 
 const DEFAULT_COMPONENT_VALUE = {}
 
@@ -8,6 +8,7 @@ type ComponentProviderType = {
   value?: ComponentData
   path?: ElementPath
   selectComponent?(e: MouseEvent): void
+  updateComponent?(path: ElementPath, newItem: HtmlNode): void
 }
 
 export function useComponent() {
@@ -35,8 +36,17 @@ export function ComponentProvider({
     setSelected(path)
     e.stopPropagation()
   }
+
+  const updateComponent = (path: ElementPath, newValue: HtmlNode) => {
+    // TODO: It's a slot!!!!!!
+    // update the `props`
+    console.log({ path, value, newValue })
+  }
+
   return (
-    <ComponentContext.Provider value={{ value, path, selectComponent }}>
+    <ComponentContext.Provider
+      value={{ value, path, selectComponent, updateComponent }}
+    >
       {children}
     </ComponentContext.Provider>
   )

--- a/packages/gui/src/components/html/Component/Provider.tsx
+++ b/packages/gui/src/components/html/Component/Provider.tsx
@@ -1,6 +1,8 @@
 import { createContext, ReactNode, useContext } from 'react'
 import { useHtmlEditor } from '../Provider'
-import { ComponentData, ElementPath, HtmlNode } from '../types'
+import { ComponentData, ElementPath, HtmlNode, Slot } from '../types'
+import { setChildAtPath } from '../util'
+import { updateSlotForComponentInstance } from './util'
 
 const DEFAULT_COMPONENT_VALUE = {}
 
@@ -9,6 +11,7 @@ type ComponentProviderType = {
   path?: ElementPath
   selectComponent?(e: MouseEvent): void
   updateComponent?(path: ElementPath, newItem: HtmlNode): void
+  updateComponentSlot?(newSlotValue: HtmlNode): void
 }
 
 export function useComponent() {
@@ -31,21 +34,51 @@ export function ComponentProvider({
   path,
   children,
 }: ComponentProviderProps) {
-  const { setSelected } = useHtmlEditor()
+  const { setSelected, value: fullValue, update, components } = useHtmlEditor()
   const selectComponent = (e: MouseEvent) => {
     setSelected(path)
     e.stopPropagation()
   }
 
-  const updateComponent = (path: ElementPath, newValue: HtmlNode) => {
-    // TODO: It's a slot!!!!!!
-    // update the `props`
-    console.log({ path, value, newValue })
+  const updateComponent = (fullEditPath: ElementPath, newValue: HtmlNode) => {
+    const component = components!.find((c) => c.id === value.id)!
+    const editPath = fullEditPath.slice(path.length)
+
+    const newComponentValue = setChildAtPath(value.value, editPath, newValue)
+    const newComponent = {
+      ...component,
+      value: newComponentValue,
+    }
+
+    const newFullValue = setChildAtPath(fullValue, path, {
+      ...value,
+      value: newComponentValue,
+    })
+
+    update(newFullValue)
+    // TODO: Emit componentUpdated with newComponent
+  }
+
+  const updateComponentSlot = (newValue: HtmlNode) => {
+    const fullComponent = updateSlotForComponentInstance(
+      value,
+      newValue as Slot
+    )
+
+    // @ts-ignore
+    const newFullValue = setChildAtPath(fullValue, path, fullComponent)
+    update(newFullValue)
   }
 
   return (
     <ComponentContext.Provider
-      value={{ value, path, selectComponent, updateComponent }}
+      value={{
+        value,
+        path,
+        selectComponent,
+        updateComponent,
+        updateComponentSlot,
+      }}
     >
       {children}
     </ComponentContext.Provider>

--- a/packages/gui/src/components/html/Component/Provider.tsx
+++ b/packages/gui/src/components/html/Component/Provider.tsx
@@ -34,7 +34,13 @@ export function ComponentProvider({
   path,
   children,
 }: ComponentProviderProps) {
-  const { setSelected, value: fullValue, update, components } = useHtmlEditor()
+  const {
+    setSelected,
+    value: fullValue,
+    update,
+    components,
+    updateComponent: emitUpdatedComponent,
+  } = useHtmlEditor()
   const selectComponent = (e: MouseEvent) => {
     setSelected(path)
     e.stopPropagation()
@@ -56,7 +62,7 @@ export function ComponentProvider({
     })
 
     update(newFullValue)
-    // TODO: Emit componentUpdated with newComponent
+    emitUpdatedComponent?.(newComponent)
   }
 
   const updateComponentSlot = (newValue: HtmlNode) => {

--- a/packages/gui/src/components/html/Component/SlotProvider.tsx
+++ b/packages/gui/src/components/html/Component/SlotProvider.tsx
@@ -1,0 +1,30 @@
+import { createContext, ReactNode, useContext } from 'react'
+import { ElementPath, Slot } from '../types'
+
+const DEFAULT_SLOT_VALUE = {}
+
+type SlotProviderType = {
+  value?: Slot
+  path?: ElementPath
+}
+
+export function useSlot() {
+  const context = useContext(SlotContext)
+  return context
+}
+
+const SlotContext = createContext<SlotProviderType>(DEFAULT_SLOT_VALUE)
+
+type SlotProviderProps = {
+  value: Slot
+  path: ElementPath
+  children: ReactNode
+}
+
+export function SlotProvider({ value, path, children }: SlotProviderProps) {
+  return (
+    <SlotContext.Provider value={{ value, path }}>
+      {children}
+    </SlotContext.Provider>
+  )
+}

--- a/packages/gui/src/components/html/Component/util.ts
+++ b/packages/gui/src/components/html/Component/util.ts
@@ -1,4 +1,4 @@
-import { ComponentData } from '../types'
+import { ComponentData, Slot } from '../types'
 
 export const mergeComponentAttributes = (value: ComponentData) => {
   const attributes = {
@@ -7,4 +7,18 @@ export const mergeComponentAttributes = (value: ComponentData) => {
   }
 
   return attributes
+}
+
+export const updateSlotForComponentInstance = (
+  value: ComponentData,
+  slotValue: Slot
+) => {
+  const props = value.props || {}
+  return {
+    ...value,
+    props: {
+      ...props,
+      [slotValue.name]: slotValue.value,
+    },
+  }
 }

--- a/packages/gui/src/components/html/Editor.tsx
+++ b/packages/gui/src/components/html/Editor.tsx
@@ -1,5 +1,4 @@
 import { Editor } from '../Editor'
-import { HtmlNode } from './types'
 import * as Tabs from '@radix-ui/react-tabs'
 import { Code, Layers, LogIn } from 'react-feather'
 import { useHtmlEditor } from './Provider'
@@ -9,10 +8,6 @@ import { useTheme } from '../providers/ThemeContext'
 import { NodeEditor } from './Editors/NodeEditor'
 import { TreeNode } from './TreeNode'
 import { Import } from './Import'
-
-interface HtmlEditorProps {
-  onChange(value: HtmlNode): void
-}
 
 const TABS_TRIGGER_STYLES: any = {
   all: 'unset',
@@ -44,8 +39,13 @@ const TABS_CONTENT_STYLES: any = {
 /**
  * An HTML tree-based editor that lets you add HTML nodes and mess around with their styles
  */
-export function HtmlEditor({ onChange }: HtmlEditorProps) {
-  const { value, selected: providedSelected, setSelected } = useHtmlEditor()
+export function HtmlEditor() {
+  const {
+    value,
+    update: onChange,
+    selected: providedSelected,
+    setSelected,
+  } = useHtmlEditor()
   const theme = useTheme()
 
   const selected = providedSelected || []

--- a/packages/gui/src/components/html/Provider.tsx
+++ b/packages/gui/src/components/html/Provider.tsx
@@ -18,10 +18,12 @@ const DEFAULT_HTML_EDITOR_VALUE = {
   isEditing: false,
   setEditing: () => {},
   hasComponents: false,
+  update: () => {},
 }
 
 export type HtmlEditor = {
   value: HtmlNode
+  update(value: HtmlNode): void
   theme?: any
   selected: ElementPath | null
   setSelected: (newSelection: ElementPath | null) => void
@@ -78,6 +80,7 @@ export const transformValueToSchema = (value: any): ElementData => {
 
 type HtmlEditorProviderProps = {
   value: HtmlNode
+  onChange(value: HtmlNode): void
   children: ReactNode
   theme?: any
   components?: ComponentData[]
@@ -88,6 +91,7 @@ export function HtmlEditorProvider({
   value,
   theme,
   components = [],
+  onChange,
 }: HtmlEditorProviderProps) {
   const [selected, setSelected] = useState<ElementPath | null>([])
   const [isEditing, setEditing] = useState(false)
@@ -102,6 +106,7 @@ export function HtmlEditorProvider({
     isEditing,
     setEditing: (newValue: any) => setEditing(newValue),
     hasComponents: !!components.length,
+    update: onChange,
   }
 
   return (

--- a/packages/gui/src/components/html/Provider.tsx
+++ b/packages/gui/src/components/html/Provider.tsx
@@ -26,10 +26,11 @@ export type HtmlEditor = {
   update(value: HtmlNode): void
   theme?: any
   selected: ElementPath | null
-  setSelected: (newSelection: ElementPath | null) => void
+  setSelected(newSelection: ElementPath | null): void
   isEditing: boolean
   setEditing(value: boolean): void
   components?: ComponentData[]
+  updateComponent?(newComponent: ComponentData): void
   hasComponents: boolean
 }
 
@@ -52,7 +53,7 @@ export const transformValueToSchema = (value: any): ElementData => {
   const fullValue = coerceNodeIntoUnist(value)
 
   const transformed = Object.entries(fullValue).reduce((acc, [key, val]) => {
-    let updatedValue = val
+    let updatedValue: any = val
     if (key === 'children' && Array.isArray(val)) {
       updatedValue = val.map((child) => transformValueToSchema(child))
     } else if (key === 'style') {
@@ -84,6 +85,7 @@ type HtmlEditorProviderProps = {
   children: ReactNode
   theme?: any
   components?: ComponentData[]
+  updateComponent?(newComponent: ComponentData): void
 }
 
 export function HtmlEditorProvider({
@@ -91,6 +93,7 @@ export function HtmlEditorProvider({
   value,
   theme,
   components = [],
+  updateComponent,
   onChange,
 }: HtmlEditorProviderProps) {
   const [selected, setSelected] = useState<ElementPath | null>([])
@@ -105,11 +108,10 @@ export function HtmlEditorProvider({
     components,
     isEditing,
     setEditing: (newValue: any) => setEditing(newValue),
+    updateComponent,
     hasComponents: !!components.length,
     update: onChange,
   }
-
-  console.log(fullContext.value)
 
   return (
     <ThemeProvider theme={theme}>

--- a/packages/gui/src/components/html/Provider.tsx
+++ b/packages/gui/src/components/html/Provider.tsx
@@ -109,6 +109,8 @@ export function HtmlEditorProvider({
     update: onChange,
   }
 
+  console.log(fullContext.value)
+
   return (
     <ThemeProvider theme={theme}>
       <HtmlEditorContext.Provider value={fullContext}>

--- a/packages/gui/src/components/html/Renderer/Element.tsx
+++ b/packages/gui/src/components/html/Renderer/Element.tsx
@@ -63,7 +63,7 @@ function ChildrenRenderer({ value = [], path }: ChildrenRendererProps) {
       {value.map((child, i) => {
         const childPath: ElementPath = [...path, i]
         if (child.type === 'text') {
-          return <TextRenderer key={i} value={child} path={path} />
+          return <TextRenderer key={i} value={child} path={childPath} />
         }
 
         return <ElementRenderer key={i} value={child} path={childPath} />

--- a/packages/gui/src/components/html/Renderer/Element.tsx
+++ b/packages/gui/src/components/html/Renderer/Element.tsx
@@ -1,6 +1,7 @@
 import { isVoidElement } from '../../../lib/elements'
 import { CanvasElementProps, useCanvasProps } from '../CanvasProvider'
 import { ComponentProvider, useComponent } from '../Component'
+import { SlotProvider } from '../Component/SlotProvider'
 import { mergeComponentAttributes } from '../Component/util'
 import { ComponentData, ElementPath, HtmlNode, Slot } from '../types'
 import { removeTailFromPath } from '../util'
@@ -129,5 +130,10 @@ function SlotRenderer({ value, path }: SlotRendererProps) {
 
   const slotValue = outerProps[value.name] || value.value
   const textNode: HtmlNode = { type: 'text', value: slotValue as string }
-  return <TextRenderer value={textNode} path={path} />
+
+  return (
+    <SlotProvider value={value} path={path}>
+      <TextRenderer value={textNode} path={path} />
+    </SlotProvider>
+  )
 }

--- a/packages/gui/src/components/html/Renderer/Text.tsx
+++ b/packages/gui/src/components/html/Renderer/Text.tsx
@@ -1,9 +1,37 @@
+import { FormEvent, FormEventHandler } from 'react'
+import { useHtmlEditor } from '../Provider'
 import { ElementPath, HtmlNode } from '../types'
+import { setChildAtPath } from '../util'
 
 type TextRendererProps = {
   value: HtmlNode
   path: ElementPath
 }
-export function TextRenderer({ value }: TextRendererProps) {
-  return <>{value.value}</>
+export function TextRenderer({ value, path }: TextRendererProps) {
+  const { value: fullValue } = useHtmlEditor()
+
+  const handleInput = (e: FormEvent) => {
+    const newText = e.currentTarget.textContent || ''
+    const newTextNode = {
+      ...value,
+      value: newText,
+    }
+
+    // We still handle the text and component types a little funky so
+    // TS isn't happy here. Need to fix that...
+    // @ts-ignore
+    const newFullValue = setChildAtPath(fullValue, path, newTextNode)
+  }
+
+  return (
+    <span
+      sx={{
+        outline: 'none',
+      }}
+      contentEditable={true}
+      onInput={handleInput}
+    >
+      {value.value as string}
+    </span>
+  )
 }

--- a/packages/gui/src/components/html/Renderer/Text.tsx
+++ b/packages/gui/src/components/html/Renderer/Text.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, FormEventHandler, useRef } from 'react'
+import { FormEvent, useCallback, useState } from 'react'
 import { useCanvas } from '../CanvasProvider'
 import { useHtmlEditor } from '../Provider'
 import { ElementPath, HtmlNode } from '../types'
@@ -14,7 +14,14 @@ export function TextRenderer({
 }: TextRendererProps) {
   const { value: fullValue, update } = useHtmlEditor()
   const { canvas } = useCanvas()
-  const value = useRef(providedValue.value)
+  const [text, setText] = useState<string>(providedValue.value as string)
+  const [editing, setEditing] = useState(false)
+
+  const textRef = useCallback(() => {
+    if (!editing) {
+      return setText(providedValue.value as string)
+    }
+  }, [providedValue])
 
   const handleInput = (e: FormEvent) => {
     const newText = e.currentTarget.textContent || ''
@@ -36,13 +43,16 @@ export function TextRenderer({
 
   return (
     <span
+      ref={textRef}
       sx={{
         outline: 'none',
       }}
       contentEditable={true}
       onInput={handleInput}
+      onBlur={() => setEditing(false)}
+      onClick={() => setEditing(true)}
     >
-      {value.current as string}
+      {text}
     </span>
   )
 }

--- a/packages/gui/src/components/html/Renderer/Text.tsx
+++ b/packages/gui/src/components/html/Renderer/Text.tsx
@@ -1,4 +1,5 @@
-import { FormEvent, FormEventHandler } from 'react'
+import { FormEvent, FormEventHandler, useRef } from 'react'
+import { useCanvas } from '../CanvasProvider'
 import { useHtmlEditor } from '../Provider'
 import { ElementPath, HtmlNode } from '../types'
 import { setChildAtPath } from '../util'
@@ -7,13 +8,18 @@ type TextRendererProps = {
   value: HtmlNode
   path: ElementPath
 }
-export function TextRenderer({ value, path }: TextRendererProps) {
-  const { value: fullValue } = useHtmlEditor()
+export function TextRenderer({
+  value: providedValue,
+  path,
+}: TextRendererProps) {
+  const { value: fullValue, update } = useHtmlEditor()
+  const { canvas } = useCanvas()
+  const value = useRef(providedValue.value)
 
   const handleInput = (e: FormEvent) => {
     const newText = e.currentTarget.textContent || ''
     const newTextNode = {
-      ...value,
+      ...providedValue,
       value: newText,
     }
 
@@ -21,6 +27,11 @@ export function TextRenderer({ value, path }: TextRendererProps) {
     // TS isn't happy here. Need to fix that...
     // @ts-ignore
     const newFullValue = setChildAtPath(fullValue, path, newTextNode)
+    update(newFullValue)
+  }
+
+  if (!canvas) {
+    return <>{providedValue.value || null}</>
   }
 
   return (
@@ -31,7 +42,7 @@ export function TextRenderer({ value, path }: TextRendererProps) {
       contentEditable={true}
       onInput={handleInput}
     >
-      {value.value as string}
+      {value.current as string}
     </span>
   )
 }

--- a/packages/gui/src/components/html/Renderer/Text.tsx
+++ b/packages/gui/src/components/html/Renderer/Text.tsx
@@ -14,18 +14,13 @@ export function TextRenderer({
   value: providedValue,
   path,
 }: TextRendererProps) {
-  const { value: slot, path: slotPath } = useSlot()
-  const {
-    value: component,
-    path: componentPath,
-    updateComponent,
-  } = useComponent()
+  const { value: slot } = useSlot()
+  const { updateComponent, updateComponentSlot } = useComponent()
   const { value: fullValue, update } = useHtmlEditor()
   const { canvas } = useCanvas()
   const [text, setText] = useState<string>(providedValue.value as string)
   const [editing, setEditing] = useState(false)
 
-  console.log({ component, componentPath, slot, slotPath })
   const textRef = useCallback(() => {
     if (!editing) {
       return setText(providedValue.value as string)
@@ -38,16 +33,15 @@ export function TextRenderer({
     }
 
     const newText = e.currentTarget.textContent || ''
-    const newTextNode = {
+    // We still handle the text and component types a little funky so
+    // TS isn't happy here. Need to fix that...
+    // @ts-ignore
+    const newTextNode: HtmlNode = {
       ...providedValue,
       value: newText,
     }
 
-    // We still handle the text and component types a little funky so
-    // TS isn't happy here. Need to fix that...
-    // @ts-ignore
-    const newFullValue = setChildAtPath(fullValue, path, newTextNode)
-    update(newFullValue)
+    updateComponent!(path, newTextNode)
   }
 
   const handleSlotInput = (e: FormEvent) => {
@@ -55,7 +49,8 @@ export function TextRenderer({
       ...(slot as Slot),
       value: e.currentTarget.textContent ?? '',
     }
-    updateComponent!(slotPath!, newSlot)
+
+    updateComponentSlot!(newSlot)
   }
 
   if (!canvas) {


### PR DESCRIPTION
- [x] Make text nodes editable in canvas
- [x] Don't set `contentEditable` when not in editor (like export rendering)
- [x] Persist changes
- [x] Ensure parent element is selected on click
- [x] Test with complex text sibling situations
- [x] Propagate inline editing for composed component
- [x] Handle slot editing from canvas for a component
- [x] Emit edits to component to the provider

https://user-images.githubusercontent.com/1424573/180281046-d9defaae-da2c-48e1-be74-5cf21e9869a7.mp4